### PR TITLE
feat: Add command-line arguments parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,44 +12,21 @@ Assuming you have [pip](https://pip.pypa.io/en/stable/installation/) installed, 
 
 Install the project requirements: `pip install -r requirements.txt`
 
-## Configuration
-There are several variables that require configuration before you can run the downloader script.
-
-`DOMAIN` must be replaced with the domain of the site you want to archive, for instance `read.substack.com`.
-
-`OUTPUT_PATH` defaults to a subdirectory titled as the domain name within the working directory. Change it if you want the files to go elsewhere. This script will attempt to create the necessary folders for a new path but may encounter permissions errors.
-
-The final value that needs configuration is the `'cookie'` field on the `HEADERS` object. It can be extracted from the browser dev tools by copying a network request to the Substack domain you're interested in. [Relevant Stack Overflow post.](https://stackoverflow.com/questions/55414344/chrome-network-request-does-not-show-cookies-tab-some-request-headers-copy-as)
-
-The usage of the remaining configuration values can be readily understood by reference to the code.
-
-Configuration section of the script:
-```
-DOMAIN = '<FILL THIS IN>'
-FULL_URL = 'https://{}'.format(DOMAIN)
-OUTPUT_PATH = './{}'.format(DOMAIN)
-PAGE_SIZE = 12
-SLEEP_SECONDS = 5
-
-HEADERS = {
-    'authority': DOMAIN,
-    'accept': '*/*',
-    'accept-language': 'en-US,en;q=0.9',
-    'cookie': '<FILL THIS IN>',
-    'dnt': '1',
-    'referer': '{}/archive?sort=new'.format(FULL_URL),
-    'sec-ch-ua': '"Not_A Brand";v="8", "Chromium";v="120", "Google Chrome";v="120"',
-    'sec-ch-ua-mobile': '?0',
-    'sec-ch-ua-platform': '"macOS"',
-    'sec-fetch-dest': 'empty',
-    'sec-fetch-mode': 'cors',
-    'sec-fetch-site': 'same-origin',
-    'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-}
-```
-
 ## Running the script
-(with project root as the working directory) `python downloader.py`
+ (with project root as the working directory) `python downloader.py <command-line-arguments>`
+
+To get help on command line parameters:
+
+ (with project root as the working directory) `python downloader.py --help`
+
+There are two required positional arguments:
+
+The first positional argument is the domain of the site you want to archive, for instance `read.substack.com`.
+
+The second positional argument is a path to the cookie file. The cookie can be extracted from the browser dev tools by copying it from a network request to the Substack domain you're interested in into the cookie file. [Relevant Stack Overflow post.](https://stackoverflow.com/questions/55414344/chrome-network-request-does-not-show-cookies-tab-some-request-headers-copy-as)
+
+The usage of the remaining optional parameters can be readily understood from the help information and by reference to the code.
+
 
 ## Limitations
 This script has only been tested on sites with text-based articles. It does not attempt to download podcast audio or videos or any other media.

--- a/downloader.py
+++ b/downloader.py
@@ -3,12 +3,14 @@ import os
 import random
 import requests
 import time
+import argparse
 
 from bs4 import BeautifulSoup
 
-DOMAIN = '<FILL THIS IN>'
-FULL_URL = 'https://{}'.format(DOMAIN)
-OUTPUT_PATH = './{}'.format(DOMAIN)
+DOMAIN = None
+FULL_URL = None
+OUTPUT_PATH = None
+
 PAGE_SIZE = 12
 SLEEP_SECONDS = 5
 
@@ -16,7 +18,7 @@ HEADERS = {
     'authority': DOMAIN,
     'accept': '*/*',
     'accept-language': 'en-US,en;q=0.9',
-    'cookie': '<FILL THIS IN>',
+    'cookie': '',
     'dnt': '1',
     'referer': '{}/archive?sort=new'.format(FULL_URL),
     'sec-ch-ua': '"Not_A Brand";v="8", "Chromium";v="120", "Google Chrome";v="120"',
@@ -102,7 +104,33 @@ def randomized_sleep():
     time.sleep(sleep_length)
 
 
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Substack Downloader",
+        epilog="See README.md for more information"
+    )
+    parser.add_argument('domain', help="domain of the site you want to archive, for instance `read.substack.com`")
+    parser.add_argument('cookie', help="path to a cookie file")
+    parser.add_argument('-o', '--output-path', dest='output', help="output path, defaults to ./{domain}")
+    parser.add_argument('-u', '--full-url', dest='url', help="full URL of the substack, defaults to https://{domain}")
+    parser.add_argument('-p', '--page-size', type=int, dest='page_size', default=PAGE_SIZE, help="page size for HTTP requests")
+    parser.add_argument('-s', '--sleep-time', type=int, dest='sleep_time', default=SLEEP_SECONDS, help="sleep time in seconds between requests")
+    return parser.parse_args()
+    
+    
 if __name__ == '__main__':
+    args = parse_args()
+
+    DOMAIN = args.domain
+    FULL_URL = args.url if args.url else 'https://{}'.format(args.domain)
+    OUTPUT_PATH = args.output if args.output else './{}'.format(args.domain)
+    with open(args.cookie, 'r') as cookie_file:
+        cookie = cookie_file.read().strip()
+        HEADERS['cookie'] = cookie
+
+    PAGE_SIZE = args.page_size
+    SLEEP_SECONDS = args.sleep_time
+
     # Ensure output directory exists before continuing.
     make_output_directory(OUTPUT_PATH)
 


### PR DESCRIPTION
Use command-line arguments instead of modifying configuration parameters directly in the script